### PR TITLE
Add link to InstructionsForAuthors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # ORJournal.github.io
-This is the Web site associated with the repository for hosting software and data associated with papers appearing in the journal Operations Research
+This is the Web site associated with the repository for hosting software and data associated with papers appearing in the journal Operations Research. The instructions for submission of accompanying software and data for authors is [here](InstructionsForAuthors).


### PR DESCRIPTION
Both `https://orjournal.github.io/InstructionsForAuthors` and `https://orjournal.github.io/InstructionsForAuthors.md` work but we should target the first one as it is the HTML version created from the markdown one.